### PR TITLE
fix: add esm extensions for nodenext

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import createError from "http-errors";
-import { verifyAccess } from "../utils/jwt";
+import { verifyAccess } from "../utils/jwt.js";
 
 export const requireAuth =
   (roles?: string[]) =>

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,10 +2,10 @@ import express from "express";
 import helmet from "helmet";
 import cors from "cors";
 import cookieParser from "cookie-parser";
-import { cfg } from "./config";
-import { connectDb } from "./db";
-import authRoutes from "./routes/auth";
-import { authLimiter } from "./middleware/rateLimit";
+import { cfg } from "./config.js";
+import { connectDb } from "./db.js";
+import authRoutes from "./routes/auth.js";
+import { authLimiter } from "./middleware/rateLimit.js";
 
 const app = express();
 app.use(helmet());


### PR DESCRIPTION
## Summary
- add explicit .js extensions to internal imports required by NodeNext module resolution

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac0a7096c8325b880466e8b8e7247