### PR TITLE
Add job tracking API with command parsing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ dotenv.config();
 export const cfg = {
   port: parseInt(process.env.PORT || "4000", 10),
   mongoUri: process.env.MONGO_URI || "",
+  mongoDbName: process.env.MONGO_DB_NAME || "karyo",
   accessSecret: process.env.JWT_ACCESS_SECRET || "",
   refreshSecret: process.env.JWT_REFRESH_SECRET || "",
   accessTtl: process.env.ACCESS_TTL || "15m",
@@ -10,5 +11,8 @@ export const cfg = {
   corsOrigin: process.env.CORS_ORIGIN || "",
   cookieDomain: process.env.COOKIE_DOMAIN || "localhost",
   appUrl: process.env.APP_URL || "",
-  emailFrom: process.env.EMAIL_FROM || "no-reply@example.com"
+  emailFrom: process.env.EMAIL_FROM || "no-reply@example.com",
+  allowedOrigins: process.env.ALLOWED_ORIGINS || "",
+  openAiApiKey: process.env.OPENAI_API_KEY || "",
+  openAiModel: process.env.OPENAI_MODEL || "gpt-4o-mini"
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,3 +1,7 @@
 import mongoose from "mongoose";
 import { cfg } from "./config.js";
-export const connectDb = async () => mongoose.connect(cfg.mongoUri);
+
+mongoose.set("strictQuery", true);
+
+export const connectDb = async () =>
+  mongoose.connect(cfg.mongoUri, { dbName: cfg.mongoDbName || "karyo" });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,11 +2,9 @@ import { Request, Response, NextFunction } from "express";
 import createError from "http-errors";
 import { verifyAccess } from "../utils/jwt.js";
 
-interface JWTPayload {
-  sub: string;
-  email?: string;
-  roles?: string[];
-  [key: string]: any;
+export interface AuthedRequest extends Request {
+  userId?: string;
+  user?: Record<string, unknown>;
 }
 
 export const requireAuth =
@@ -17,16 +15,23 @@ export const requireAuth =
       const token = hdr.startsWith("Bearer ") ? hdr.slice(7) : null;
       if (!token) throw createError(401, "missing_token");
 
-      const { payload } = (await verifyAccess(token)) as { payload: JWTPayload };
+      const { payload } = await verifyAccess(token);
 
-      if (
-        roles?.length &&
-        !payload.roles?.some((r) => roles.includes(r))
-      ) {
+      const payloadRoles = Array.isArray((payload as { roles?: unknown }).roles)
+        ? ((payload as { roles?: unknown }).roles as unknown[]).map((r) =>
+            String(r)
+          )
+        : [];
+
+      if (roles?.length && !payloadRoles.some((r) => roles.includes(r))) {
         throw createError(403, "forbidden");
       }
 
-      (req as any).user = payload;
+      const authed = req as AuthedRequest;
+      authed.user = payload as Record<string, unknown>;
+      authed.userId = String(payload.sub || payload.userId || payload.uid || "");
+      if (!authed.userId) throw createError(401, "unauthorized");
+
       next();
     } catch (e: any) {
       next(createError(e.status || 401, e.message || "unauthorized"));

--- a/src/models/CommandDedup.ts
+++ b/src/models/CommandDedup.ts
@@ -1,0 +1,26 @@
+import { Schema, model } from "mongoose";
+
+export interface ICommandDedup {
+  _id: string;
+  userId: string;
+  command: Record<string, unknown>;
+  status: "APPLIED" | "IGNORED";
+  createdAt: Date;
+}
+
+const CommandDedupSchema = new Schema<ICommandDedup>(
+  {
+    _id: { type: String, required: true },
+    userId: { type: String, required: true },
+    command: { type: Object, required: true },
+    status: { type: String, enum: ["APPLIED", "IGNORED"], required: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+CommandDedupSchema.index({ userId: 1, _id: 1 }, { unique: true });
+
+export const CommandDedup = model<ICommandDedup>(
+  "CommandDedup",
+  CommandDedupSchema
+);

--- a/src/models/Job.ts
+++ b/src/models/Job.ts
@@ -1,0 +1,49 @@
+import { Schema, model, Types } from "mongoose";
+
+export type Stage =
+  | "WISHLIST"
+  | "APPLIED"
+  | "INTERVIEW"
+  | "OFFER"
+  | "ARCHIVED";
+
+export interface IJob {
+  _id: Types.ObjectId;
+  userId: string;
+  title: string;
+  company: string;
+  location?: string;
+  sourceUrl?: string;
+  priority: "starred" | "normal";
+  stage: Stage;
+  appliedOn?: Date | null;
+  notesCount: number;
+  archived: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const JobSchema = new Schema<IJob>(
+  {
+    userId: { type: String, index: true, required: true },
+    title: { type: String, required: true },
+    company: { type: String, required: true },
+    location: { type: String },
+    sourceUrl: { type: String },
+    priority: { type: String, enum: ["starred", "normal"], default: "normal" },
+    stage: {
+      type: String,
+      enum: ["WISHLIST", "APPLIED", "INTERVIEW", "OFFER", "ARCHIVED"],
+      default: "WISHLIST",
+      index: true,
+    },
+    appliedOn: { type: Date },
+    notesCount: { type: Number, default: 0 },
+    archived: { type: Boolean, default: false, index: true },
+  },
+  { timestamps: true }
+);
+
+JobSchema.index({ userId: 1, archived: 1, stage: 1, updatedAt: -1 });
+
+export const Job = model<IJob>("Job", JobSchema);

--- a/src/models/JobAudit.ts
+++ b/src/models/JobAudit.ts
@@ -1,0 +1,40 @@
+import { Schema, model, Types } from "mongoose";
+
+export type AuditAction =
+  | "CREATE"
+  | "UPDATE"
+  | "MOVE_STAGE"
+  | "ARCHIVE"
+  | "RESTORE"
+  | "COMMENT";
+
+export interface IJobAudit {
+  _id: Types.ObjectId;
+  jobId: Types.ObjectId;
+  userId: string;
+  action: AuditAction;
+  fromStage?: string;
+  toStage?: string;
+  meta?: Record<string, unknown>;
+  createdAt: Date;
+}
+
+const JobAuditSchema = new Schema<IJobAudit>(
+  {
+    jobId: { type: Schema.Types.ObjectId, index: true, required: true },
+    userId: { type: String, required: true },
+    action: {
+      type: String,
+      enum: ["CREATE", "UPDATE", "MOVE_STAGE", "ARCHIVE", "RESTORE", "COMMENT"],
+      required: true,
+    },
+    fromStage: { type: String },
+    toStage: { type: String },
+    meta: { type: Object },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+JobAuditSchema.index({ jobId: 1, createdAt: -1 });
+
+export const JobAudit = model<IJobAudit>("JobAudit", JobAuditSchema);

--- a/src/models/JobComment.ts
+++ b/src/models/JobComment.ts
@@ -1,0 +1,22 @@
+import { Schema, model, Types } from "mongoose";
+
+export interface IJobComment {
+  _id: Types.ObjectId;
+  jobId: Types.ObjectId;
+  userId: string;
+  text: string;
+  createdAt: Date;
+}
+
+const JobCommentSchema = new Schema<IJobComment>(
+  {
+    jobId: { type: Schema.Types.ObjectId, index: true, required: true },
+    userId: { type: String, required: true },
+    text: { type: String, required: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+JobCommentSchema.index({ jobId: 1, createdAt: -1 });
+
+export const JobComment = model<IJobComment>("JobComment", JobCommentSchema);

--- a/src/routes/audit.ts
+++ b/src/routes/audit.ts
@@ -1,0 +1,51 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireAuth, AuthedRequest } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import { Job } from "../models/Job.js";
+import { JobAudit } from "../models/JobAudit.js";
+import { encodeCursor, decodeCursor } from "../utils/cursor.js";
+
+const r = Router();
+
+r.get(
+  "/:id/audit",
+  requireAuth(),
+  validate(
+    z.object({
+      query: z.object({
+        limit: z.coerce.number().min(1).max(100).default(50).optional(),
+        cursor: z.string().optional(),
+      }),
+    })
+  ),
+  async (req, res) => {
+    const ar = req as AuthedRequest & { data?: { query: { limit?: number; cursor?: string } } };
+    const job = await Job.findOne({ _id: req.params.id, userId: ar.userId });
+    if (!job) return res.status(404).json({ error: "not_found" });
+
+    const { query } = (req as { data?: { query: { limit?: number; cursor?: string } } }).data ?? { query: {} };
+    const { limit = 50, cursor } = query;
+
+    const filter: Record<string, unknown> = { jobId: job._id };
+    const cur = decodeCursor(cursor);
+    const sort = { createdAt: -1, _id: -1 } as const;
+    if (cur?.u && cur?.i) {
+      filter.$or = [
+        { createdAt: { $lt: new Date(cur.u) } },
+        { createdAt: new Date(cur.u), _id: { $lt: cur.i } },
+      ];
+    }
+
+    const items = await JobAudit.find(filter)
+      .sort(sort)
+      .limit(Number(limit) + 1);
+    const hasMore = items.length > Number(limit);
+    const page = hasMore ? items.slice(0, -1) : items;
+    const next = hasMore ? encodeCursor(page[page.length - 1]) : null;
+
+    res.json({ items: page, nextCursor: next });
+  }
+);
+
+export default r;

--- a/src/routes/commands.ts
+++ b/src/routes/commands.ts
@@ -1,0 +1,166 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireAuth, AuthedRequest } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import { CommandDedup } from "../models/CommandDedup.js";
+import { Job } from "../models/Job.js";
+import { JobComment } from "../models/JobComment.js";
+import { writeAudit } from "../services/auditHook.js";
+import { parseCommand } from "../services/commandParser.js";
+
+const r = Router();
+
+const bodySchema = z.object({
+  body: z.object({
+    channel: z.enum(["voice", "text"]),
+    transcript: z.string().min(1),
+    requestId: z.string().min(1),
+  }),
+});
+
+r.post("/", requireAuth(), validate(bodySchema), async (req, res) => {
+  const ar = req as AuthedRequest & {
+    data?: {
+      body: { channel: "voice" | "text"; transcript: string; requestId: string };
+    };
+  };
+  const { body } = (req as typeof ar).data!;
+  const { transcript, requestId } = body;
+
+  try {
+    await CommandDedup.create({
+      _id: requestId,
+      userId: ar.userId!,
+      command: body,
+      status: "APPLIED",
+    });
+  } catch {
+    return res.json({ status: "IGNORED_DUPLICATE", requestId });
+  }
+
+  const parsed = await parseCommand(transcript);
+  const intent = parsed?.intent as string | undefined;
+  const args = (parsed?.args || {}) as Record<string, unknown>;
+
+  if (!intent) {
+    return res.json({
+      status: "NEED_CLARIFICATION",
+      question: "What do you want to do?",
+      options: [],
+      requestId,
+    });
+  }
+
+  if (intent === "MOVE_STAGE") {
+    const stage = args.stage as string | undefined;
+    const query: Record<string, unknown> = { userId: ar.userId };
+    const company = args.company as string | undefined;
+    const title = args.title as string | undefined;
+    if (company) query.company = new RegExp(`^${company}$`, "i");
+    if (title) query.title = new RegExp(`^${title}$`, "i");
+    const matches = await Job.find(query).limit(5);
+
+    if (matches.length !== 1 || !stage) {
+      const options = matches.map((j) => ({
+        jobId: String(j._id),
+        company: j.company,
+        title: j.title,
+      }));
+      return res.json({
+        status: "NEED_CLARIFICATION",
+        question: "Which job?",
+        options,
+        requestId,
+      });
+    }
+
+    const job = matches[0];
+    const fromStage = job.stage;
+    await Job.updateOne({ _id: job._id }, { $set: { stage } });
+    await writeAudit({
+      jobId: job._id,
+      userId: ar.userId!,
+      action: "MOVE_STAGE",
+      fromStage,
+      toStage: stage,
+      meta: { requestId, source: body.channel },
+    });
+    return res.json({
+      status: "APPLIED",
+      effects: [{ type: "MOVE_STAGE", jobId: String(job._id), to: stage }],
+    });
+  }
+
+  if (intent === "COMMENT") {
+    const query: Record<string, unknown> = { userId: ar.userId };
+    const company = args.company as string | undefined;
+    const title = args.title as string | undefined;
+    if (company) query.company = new RegExp(`^${company}$`, "i");
+    if (title) query.title = new RegExp(`^${title}$`, "i");
+    const matches = await Job.find(query).limit(5);
+
+    if (matches.length !== 1) {
+      const options = matches.map((j) => ({
+        jobId: String(j._id),
+        company: j.company,
+        title: j.title,
+      }));
+      return res.json({
+        status: "NEED_CLARIFICATION",
+        question: "Which job?",
+        options,
+        requestId,
+      });
+    }
+
+    const job = matches[0];
+    const text = (args.text as string | undefined) || transcript;
+    const comment = await JobComment.create({
+      jobId: job._id,
+      userId: ar.userId!,
+      text,
+    });
+    await Job.updateOne({ _id: job._id }, { $inc: { notesCount: 1 } });
+    await writeAudit({
+      jobId: job._id,
+      userId: ar.userId!,
+      action: "COMMENT",
+      meta: { requestId, source: body.channel },
+    });
+    return res.json({
+      status: "APPLIED",
+      effects: [
+        { type: "COMMENT", jobId: String(comment.jobId), commentId: String(comment._id) },
+      ],
+    });
+  }
+
+  if (intent === "CREATE") {
+    const doc = await Job.create({
+      userId: ar.userId!,
+      title: (args.title as string | undefined) || "Untitled",
+      company: (args.company as string | undefined) || "Unknown",
+      location: (args.location as string | undefined) || "",
+      stage: (args.stage as string | undefined) || "WISHLIST",
+    });
+    await writeAudit({
+      jobId: doc._id,
+      userId: ar.userId!,
+      action: "CREATE",
+      meta: { requestId, source: body.channel },
+    });
+    return res.json({
+      status: "APPLIED",
+      effects: [{ type: "CREATE", jobId: String(doc._id) }],
+    });
+  }
+
+  return res.json({
+    status: "NEED_CLARIFICATION",
+    question: "Please specify the action.",
+    options: [],
+    requestId,
+  });
+});
+
+export default r;

--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -1,0 +1,74 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireAuth, AuthedRequest } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import { Job } from "../models/Job.js";
+import { JobComment } from "../models/JobComment.js";
+import { writeAudit } from "../services/auditHook.js";
+import { encodeCursor, decodeCursor } from "../utils/cursor.js";
+
+const r = Router();
+
+r.post(
+  "/:id/comments",
+  requireAuth(),
+  validate(z.object({ body: z.object({ text: z.string().min(1) }) })),
+  async (req, res) => {
+    const ar = req as AuthedRequest & { data?: { body: { text: string } } };
+    const job = await Job.findOne({ _id: req.params.id, userId: ar.userId });
+    if (!job) return res.status(404).json({ error: "not_found" });
+
+    const { body } = (req as { data?: { body: { text: string } } }).data ?? { body: { text: "" } };
+    const comment = await JobComment.create({
+      jobId: job._id,
+      userId: ar.userId!,
+      text: body.text,
+    });
+    await Job.updateOne({ _id: job._id }, { $inc: { notesCount: 1 } });
+    await writeAudit({ jobId: job._id, userId: ar.userId!, action: "COMMENT" });
+
+    res.status(201).json(comment);
+  }
+);
+
+r.get(
+  "/:id/comments",
+  requireAuth(),
+  validate(
+    z.object({
+      query: z.object({
+        limit: z.coerce.number().min(1).max(100).default(20).optional(),
+        cursor: z.string().optional(),
+      }),
+    })
+  ),
+  async (req, res) => {
+    const ar = req as AuthedRequest & { data?: { query: { limit?: number; cursor?: string } } };
+    const job = await Job.findOne({ _id: req.params.id, userId: ar.userId });
+    if (!job) return res.status(404).json({ error: "not_found" });
+
+    const { query } = (req as { data?: { query: { limit?: number; cursor?: string } } }).data ?? { query: {} };
+    const { limit = 20, cursor } = query;
+
+    const filter: Record<string, unknown> = { jobId: job._id };
+    const cur = decodeCursor(cursor);
+    const sort = { createdAt: -1, _id: -1 } as const;
+    if (cur?.u && cur?.i) {
+      filter.$or = [
+        { createdAt: { $lt: new Date(cur.u) } },
+        { createdAt: new Date(cur.u), _id: { $lt: cur.i } },
+      ];
+    }
+
+    const items = await JobComment.find(filter)
+      .sort(sort)
+      .limit(Number(limit) + 1);
+    const hasMore = items.length > Number(limit);
+    const page = hasMore ? items.slice(0, -1) : items;
+    const next = hasMore ? encodeCursor(page[page.length - 1]) : null;
+
+    res.json({ items: page, nextCursor: next });
+  }
+);
+
+export default r;

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,0 +1,33 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validate } from "../middleware/validate.js";
+import { parseJobLink } from "../services/parser.js";
+import { parseCommand } from "../services/commandParser.js";
+
+const r = Router();
+
+r.post(
+  "/parser/link",
+  validate(z.object({ body: z.object({ sourceUrl: z.string().url() }) })),
+  async (req, res) => {
+    const { body } = (req as { data?: { body: { sourceUrl: string } } }).data ?? {
+      body: { sourceUrl: "" },
+    };
+    const data = await parseJobLink(body.sourceUrl);
+    res.json(data);
+  }
+);
+
+r.post(
+  "/commands/parse",
+  validate(z.object({ body: z.object({ transcript: z.string().min(1) }) })),
+  async (req, res) => {
+    const { body } = (req as { data?: { body: { transcript: string } } }).data ?? {
+      body: { transcript: "" },
+    };
+    const data = await parseCommand(body.transcript);
+    res.json(data);
+  }
+);
+
+export default r;

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -1,0 +1,185 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireAuth, AuthedRequest } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import { Job } from "../models/Job.js";
+import { JobComment } from "../models/JobComment.js";
+import { JobAudit } from "../models/JobAudit.js";
+import { writeAudit } from "../services/auditHook.js";
+import { encodeCursor, decodeCursor } from "../utils/cursor.js";
+
+const r = Router();
+
+r.post(
+  "/",
+  requireAuth(),
+  validate(
+    z.object({
+      body: z.object({
+        title: z.string().min(1),
+        company: z.string().min(1),
+        location: z.string().optional(),
+        sourceUrl: z.string().url().optional(),
+        priority: z.enum(["starred", "normal"]).optional(),
+        stage: z
+          .enum(["WISHLIST", "APPLIED", "INTERVIEW", "OFFER", "ARCHIVED"])
+          .optional(),
+        appliedOn: z.coerce.date().optional(),
+      }),
+    })
+  ),
+  async (req, res) => {
+    const ar = req as AuthedRequest & {
+      data?: {
+        body: {
+          title: string;
+          company: string;
+          location?: string;
+          sourceUrl?: string;
+          priority?: "starred" | "normal";
+          stage?: string;
+          appliedOn?: Date;
+        };
+      };
+    };
+    const { body } = (req as typeof ar).data!;
+    const doc = await Job.create({ ...body, userId: ar.userId });
+    await writeAudit({ jobId: doc._id, userId: ar.userId!, action: "CREATE" });
+    res.status(201).json(doc);
+  }
+);
+
+r.get(
+  "/",
+  requireAuth(),
+  validate(
+    z.object({
+      query: z.object({
+        stage: z
+          .enum(["WISHLIST", "APPLIED", "INTERVIEW", "OFFER", "ARCHIVED"])
+          .optional(),
+        archived: z.coerce.boolean().optional(),
+        limit: z.coerce.number().min(1).max(100).default(50).optional(),
+        cursor: z.string().optional(),
+      }),
+    })
+  ),
+  async (req, res) => {
+    const ar = req as AuthedRequest & { data?: { query: { [key: string]: unknown } } };
+    const { query } = (req as typeof ar).data ?? { query: {} };
+    const { stage, archived, limit = 50, cursor } = query as {
+      stage?: string;
+      archived?: boolean;
+      limit?: number;
+      cursor?: string;
+    };
+
+    const filter: Record<string, unknown> = { userId: ar.userId };
+    if (stage !== undefined) filter.stage = stage;
+    if (archived !== undefined) filter.archived = archived;
+
+    const sort = { updatedAt: -1, _id: -1 } as const;
+    const cur = decodeCursor(cursor);
+    if (cur?.u && cur?.i) {
+      filter.$or = [
+        { updatedAt: { $lt: new Date(cur.u) } },
+        { updatedAt: new Date(cur.u), _id: { $lt: cur.i } },
+      ];
+    }
+
+    const docs = await Job.find(filter)
+      .sort(sort)
+      .limit(Number(limit) + 1);
+    const hasMore = docs.length > Number(limit);
+    const page = hasMore ? docs.slice(0, -1) : docs;
+    const next = hasMore ? encodeCursor(page[page.length - 1]) : null;
+    res.json({ items: page, nextCursor: next });
+  }
+);
+
+r.get("/:id", requireAuth(), async (req, res) => {
+  const ar = req as AuthedRequest;
+  const job = await Job.findOne({ _id: req.params.id, userId: ar.userId });
+  if (!job) return res.status(404).json({ error: "not_found" });
+  const comments = await JobComment.find({ jobId: job._id })
+    .sort({ createdAt: -1 })
+    .limit(5);
+  const audits = await JobAudit.find({ jobId: job._id })
+    .sort({ createdAt: -1 })
+    .limit(5);
+  res.json({ job, comments, audits });
+});
+
+r.patch(
+  "/:id",
+  requireAuth(),
+  validate(
+    z.object({
+      body: z
+        .object({
+          title: z.string().optional(),
+          company: z.string().optional(),
+          location: z.string().optional(),
+          sourceUrl: z.string().url().optional(),
+          priority: z.enum(["starred", "normal"]).optional(),
+          stage: z
+            .enum(["WISHLIST", "APPLIED", "INTERVIEW", "OFFER", "ARCHIVED"])
+            .optional(),
+          appliedOn: z.coerce.date().nullable().optional(),
+          archived: z.boolean().optional(),
+        })
+        .refine((v) => Object.keys(v).length > 0, "no_fields"),
+    })
+  ),
+  async (req, res) => {
+    const ar = req as AuthedRequest & {
+      data?: { body: Record<string, unknown> };
+    };
+    const before = await Job.findOne({ _id: req.params.id, userId: ar.userId });
+    if (!before) return res.status(404).json({ error: "not_found" });
+
+    const { body } = (req as typeof ar).data!;
+    const fromStage = before.stage;
+
+    await Job.updateOne({ _id: before._id }, { $set: body });
+    const after = await Job.findById(before._id);
+
+    const changedStage = typeof body.stage === "string" && body.stage !== fromStage;
+    await writeAudit({
+      jobId: before._id,
+      userId: ar.userId!,
+      action: changedStage ? "MOVE_STAGE" : "UPDATE",
+      fromStage: changedStage ? fromStage : undefined,
+      toStage: changedStage ? (body.stage as string) : undefined,
+    });
+    res.json(after);
+  }
+);
+
+r.post("/:id/archive", requireAuth(), async (req, res) => {
+  const ar = req as AuthedRequest;
+  const job = await Job.findOne({ _id: req.params.id, userId: ar.userId });
+  if (!job) return res.status(404).json({ error: "not_found" });
+  await Job.updateOne(
+    { _id: job._id },
+    { $set: { archived: true, stage: "ARCHIVED" } }
+  );
+  await writeAudit({ jobId: job._id, userId: ar.userId!, action: "ARCHIVE" });
+  const updated = await Job.findById(job._id);
+  res.json(updated);
+});
+
+r.post("/:id/restore", requireAuth(), async (req, res) => {
+  const ar = req as AuthedRequest;
+  const job = await Job.findOne({ _id: req.params.id, userId: ar.userId });
+  if (!job) return res.status(404).json({ error: "not_found" });
+  await Job.updateOne(
+    { _id: job._id },
+    { $set: { archived: false, stage: "WISHLIST" } }
+  );
+  await writeAudit({ jobId: job._id, userId: ar.userId!, action: "RESTORE" });
+  const updated = await Job.findById(job._id);
+  res.json(updated);
+});
+
+export default r;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,29 +5,65 @@ type HelmetFactory = typeof import("helmet") extends { default: infer T }
   : never;
 import cors from "cors";
 import cookieParser from "cookie-parser";
+import rateLimitModule from "express-rate-limit";
 import { cfg } from "./config.js";
 import { connectDb } from "./db.js";
 import authRoutes from "./routes/auth.js";
 import { authLimiter } from "./middleware/rateLimit.js";
+import jobs from "./routes/jobs.js";
+import comments from "./routes/comments.js";
+import audit from "./routes/audit.js";
+import commands from "./routes/commands.js";
+import internal from "./routes/internal.js";
 
 const helmet =
   typeof helmetModule === "function"
     ? (helmetModule as HelmetFactory)
     : (helmetModule as { default: HelmetFactory }).default;
 
+type RateLimitFactory = typeof rateLimitModule extends {
+  default: infer T;
+}
+  ? T
+  : typeof rateLimitModule;
+
+const rateLimit =
+  typeof rateLimitModule === "function"
+    ? (rateLimitModule as RateLimitFactory)
+    : (rateLimitModule as { default: RateLimitFactory }).default;
+
 const app = express();
+
+const origins = (cfg.allowedOrigins || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 app.use(helmet());
-app.use(express.json());
-app.use(cookieParser());
 app.use(
   cors({
-    origin: ["https://intervieweasy.io", "https://karyo.intervieweasy.io", /http:\/\/127\.0\.0\.1:300\d/ ], 
+    origin: origins,
     credentials: true,
-    methods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
-    allowedHeaders: ["Content-Type", "Authorization"]
+    methods: ["GET", "POST", "PATCH", "DELETE"],
+    allowedHeaders: ["Content-Type", "Authorization"],
   })
 );
+app.use(express.json({ limit: "1mb" }));
+app.use(cookieParser());
+app.use((req, _res, next) => {
+  console.log(`${req.method} ${req.originalUrl}`);
+  next();
+});
+app.use(rateLimit({ windowMs: 60_000, limit: 300 }));
+
 app.use("/api/auth", authLimiter, authRoutes);
+app.use("/api/core/jobs", jobs);
+app.use("/api/core/jobs", comments);
+app.use("/api/core/jobs", audit);
+app.use("/api/core/commands", commands);
+app.use("/api/core/internal", internal);
+
+app.get("/api/core/health", (_, res) => res.json({ ok: true }));
 app.get("/api/health", (_, res) => res.json({ ok: true }));
 
 const start = async () => {

--- a/src/services/auditHook.ts
+++ b/src/services/auditHook.ts
@@ -1,0 +1,13 @@
+import { Types } from "mongoose";
+import { AuditAction, JobAudit } from "../models/JobAudit.js";
+
+export const writeAudit = async (params: {
+  jobId: Types.ObjectId;
+  userId: string;
+  action: AuditAction;
+  fromStage?: string;
+  toStage?: string;
+  meta?: Record<string, unknown>;
+}) => {
+  await JobAudit.create({ ...params });
+};

--- a/src/services/commandParser.ts
+++ b/src/services/commandParser.ts
@@ -1,0 +1,38 @@
+import { cfg } from "../config.js";
+
+const sys =
+  'You transform a short command transcript into strict JSON: {"intent":"CREATE|UPDATE|MOVE_STAGE|ARCHIVE|RESTORE|COMMENT","args":{}} Stages: WISHLIST, APPLIED, INTERVIEW, OFFER, ARCHIVED.';
+
+export type ParsedCommand = { intent?: string; args?: Record<string, unknown> };
+
+export const parseCommand = async (
+  transcript: string
+): Promise<ParsedCommand> => {
+  if (!cfg.openAiApiKey) return {};
+  try {
+    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${cfg.openAiApiKey}`,
+      },
+      body: JSON.stringify({
+        model: cfg.openAiModel,
+        messages: [
+          { role: "system", content: sys },
+          { role: "user", content: transcript },
+        ],
+        temperature: 0,
+        response_format: { type: "json_object" },
+      }),
+    });
+    if (!resp.ok) return {};
+    const data = (await resp.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content || "{}";
+    return JSON.parse(content) as ParsedCommand;
+  } catch {
+    return {};
+  }
+};

--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -1,0 +1,23 @@
+export const parseJobLink = async (sourceUrl: string) => {
+  const url = new URL(sourceUrl);
+  const host = url.hostname.toLowerCase();
+  if (host.includes("greenhouse")) {
+    return {
+      title: "Engineer",
+      company: url.hostname.split(".")[0],
+      location: "",
+    };
+  }
+  if (host.includes("lever")) {
+    return {
+      title: "Engineer",
+      company: url.hostname.split(".")[0],
+      location: "",
+    };
+  }
+  return {
+    title: "",
+    company: url.hostname.replace("www.", ""),
+    location: "",
+  };
+};

--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -1,0 +1,24 @@
+export type CursorPayload = { u?: string; i?: string };
+
+export const encodeCursor = (doc: {
+  updatedAt?: Date;
+  createdAt?: Date;
+  _id: unknown;
+}): string => {
+  const u = (doc as { updatedAt?: Date; createdAt?: Date }).updatedAt ||
+    (doc as { createdAt?: Date }).createdAt;
+  const payload: CursorPayload = {
+    u: u ? u.toISOString() : undefined,
+    i: String((doc as { _id: unknown })._id),
+  };
+  return Buffer.from(JSON.stringify(payload)).toString("base64");
+};
+
+export const decodeCursor = (c?: string | null): CursorPayload | null => {
+  if (!c) return null;
+  try {
+    return JSON.parse(Buffer.from(c, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add MongoDB models for jobs, job comments, audits, and command deduplication
- implement job, comment, audit, and command routes with cursor-based pagination and audit logging
- integrate OpenAI-backed command parsing fallback and wire new routes into the server configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2953b39ac83258e30f8cf8baf7dc3