### PR TITLE
Add OpenAI health check endpoint

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,10 +1,40 @@
 import { Router } from "express";
 import { z } from "zod";
+import { cfg } from "../config.js";
 import { validate } from "../middleware/validate.js";
 import { parseJobLink } from "../services/parser.js";
 import { parseCommand } from "../services/commandParser.js";
 
 const r = Router();
+
+r.get("/openai/health", async (_req, res) => {
+  if (!cfg.openAiApiKey) {
+    res.status(500).json({ ok: false, error: "OpenAI API key not configured" });
+    return;
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/models", {
+      headers: {
+        Authorization: `Bearer ${cfg.openAiApiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      res.status(502).json({
+        ok: false,
+        error: "OpenAI API returned a non-OK status",
+        status: response.status,
+      });
+      return;
+    }
+
+    res.json({ ok: true });
+  } catch (error) {
+    console.error("OpenAI health check failed", error);
+    res.status(500).json({ ok: false, error: "Failed to reach OpenAI" });
+  }
+});
 
 r.post(
   "/parser/link",


### PR DESCRIPTION
## Summary
- add an internal OpenAI health check endpoint that validates connectivity to the OpenAI API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3654d508c8325bf6fdb6cbae78bfc