### PR TITLE
Add Cloudflare file endpoints and enhance poll details

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,5 +15,8 @@ export const cfg = {
   allowedOrigins: process.env.ALLOWED_ORIGINS || "",
   allowedSignupEmails: process.env.ALLOWED_SIGNUP_EMAILS || "",
   openAiApiKey: process.env.OPENAI_API_KEY || "",
-  openAiModel: process.env.OPENAI_MODEL || "gpt-4o-mini"
+  openAiModel: process.env.OPENAI_MODEL || "gpt-4o-mini",
+  cloudflareAccountId: process.env.CLOUDFLARE_ACCOUNT_ID || "",
+  cloudflareImagesToken: process.env.CLOUDFLARE_IMAGES_TOKEN || "",
+  cloudflareImagesBaseUrl: process.env.CLOUDFLARE_IMAGES_BASE_URL || "",
 };

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -1,0 +1,52 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireAuth, AuthedRequest } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import { requestDirectUpload, buildDeliveryUrl } from "../services/cloudflare.js";
+
+const r = Router();
+
+const uploadSchema = z.object({
+  metadata: z.record(z.string(), z.string()).optional(),
+  expirySeconds: z.number().int().positive().max(7 * 24 * 60 * 60).optional(),
+});
+
+r.post(
+  "/upload",
+  requireAuth(),
+  validate(z.object({ body: uploadSchema })),
+  async (req, res) => {
+    const ar = req as AuthedRequest & { data?: { body: z.infer<typeof uploadSchema> } };
+    try {
+      const { metadata, expirySeconds } = (req as typeof ar).data!.body;
+      const result = await requestDirectUpload({ metadata, expirySeconds });
+      res.json({ id: result.id, uploadUrl: result.uploadURL });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown_error";
+      res.status(500).json({ error: "cloudflare_upload_error", message });
+    }
+  }
+);
+
+const downloadParamsSchema = z.object({ id: z.string().min(1) });
+const downloadQuerySchema = z.object({ variant: z.string().min(1).optional() });
+
+r.get(
+  "/download/:id",
+  requireAuth(),
+  validate(z.object({ params: downloadParamsSchema, query: downloadQuerySchema })),
+  async (req, res) => {
+    const ar = req as AuthedRequest & { data?: { params: z.infer<typeof downloadParamsSchema>; query: z.infer<typeof downloadQuerySchema> } };
+    try {
+      const { id } = (req as typeof ar).data!.params;
+      const { variant } = (req as typeof ar).data!.query;
+      const url = buildDeliveryUrl(id, variant ?? null);
+      res.json({ id, url });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown_error";
+      res.status(500).json({ error: "cloudflare_download_error", message });
+    }
+  }
+);
+
+export default r;

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import engage from "./routes/engage.js";
 import feed from "./routes/feed.js";
 import graph from "./routes/graph.js";
 import pods from "./routes/pods.js";
+import files from "./routes/files.js";
 
 const helmet =
   typeof helmetModule === "function"
@@ -74,6 +75,7 @@ app.use("/api/engage", engage);
 app.use("/api/feed", feed);
 app.use("/api/graph", graph);
 app.use("/api/pods", pods);
+app.use("/api/files", files);
 
 app.use("/openai", openai);
 

--- a/src/services/cloudflare.ts
+++ b/src/services/cloudflare.ts
@@ -1,0 +1,64 @@
+import { cfg } from "../config.js";
+
+interface DirectUploadOptions {
+  metadata?: Record<string, string>;
+  expirySeconds?: number;
+}
+
+interface DirectUploadResult {
+  id: string;
+  uploadURL: string;
+}
+
+const ensureConfig = () => {
+  if (!cfg.cloudflareAccountId || !cfg.cloudflareImagesToken) {
+    throw new Error("cloudflare_images_not_configured");
+  }
+};
+
+export const requestDirectUpload = async (
+  options: DirectUploadOptions = {}
+): Promise<DirectUploadResult> => {
+  ensureConfig();
+  const url = `https://api.cloudflare.com/client/v4/accounts/${cfg.cloudflareAccountId}/images/v2/direct_upload`;
+  const body: Record<string, unknown> = {};
+  if (options.metadata && Object.keys(options.metadata).length > 0) {
+    body.metadata = options.metadata;
+  }
+  if (options.expirySeconds && options.expirySeconds > 0) {
+    body.expiry = Math.floor(Date.now() / 1000) + options.expirySeconds;
+  }
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${cfg.cloudflareImagesToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`cloudflare_direct_upload_failed:${response.status}:${text}`);
+  }
+  const json = (await response.json()) as {
+    success: boolean;
+    result?: DirectUploadResult;
+    errors?: { message?: string }[];
+  };
+  if (!json.success || !json.result) {
+    const message = json.errors?.map((e) => e.message).filter(Boolean).join(", ") || "unknown_error";
+    throw new Error(`cloudflare_direct_upload_failed:${message}`);
+  }
+  return json.result;
+};
+
+export const buildDeliveryUrl = (id: string, variant?: string | null): string => {
+  if (!cfg.cloudflareImagesBaseUrl) {
+    throw new Error("cloudflare_images_not_configured");
+  }
+  const trimmedBase = cfg.cloudflareImagesBaseUrl.replace(/\/$/, "");
+  if (variant) {
+    return `${trimmedBase}/${variant}/${id}`;
+  }
+  return `${trimmedBase}/${id}`;
+};


### PR DESCRIPTION
## Summary
- add Cloudflare Images configuration along with a service wrapper and secured upload/download routes
- include the files router in the Express app to expose new CDN helper endpoints
- enrich post polling responses with vote aggregates and the requesting user's selections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690378817e7c8325b3676992991c5e46